### PR TITLE
get_events: uniq the events, preventing duplicates

### DIFF
--- a/lib/cinch/test.rb
+++ b/lib/cinch/test.rb
@@ -175,7 +175,7 @@ module Cinch
       # If the message is :private also trigger :message
       events << :message if events.include?(:private)
 
-      events
+      events.uniq
     end
   end
 end

--- a/spec/cinch_test_spec.rb
+++ b/spec/cinch_test_spec.rb
@@ -39,6 +39,12 @@ describe Cinch::Test do
       expect(replies.first.text).to eq('bar reply')
     end
 
+    it 'sent directly to bot get correct number of replies' do
+      message = make_message(@bot, '!bar')
+      replies = get_replies(message)
+      expect(replies.size).to eq(1)
+    end
+
     it 'sent directly to a test bot and can receive a prefixed reply' do
       replies = get_replies(make_message(@bot, '!baz'))
       expect(replies.first.text).to eq('test: baz reply')
@@ -53,6 +59,12 @@ describe Cinch::Test do
     it 'sent to a bot can be responded to with a logged action' do
       replies = get_replies(make_message(@bot, '!scallops'))
       expect(replies.first.text).to eq('loves shellfish')
+    end
+
+    it 'sent to a channel get correct number of replies' do
+      message = make_message(@bot, '!bar', channel: '#test')
+      replies = get_replies(message)
+      expect(replies.size).to eq(1)
     end
 
     it 'should trigger listeners' do


### PR DESCRIPTION
by default, get_replies has event = :message, but get_events also
appends :message to the event type array. This means that the following
triggers two :message replies from the bot:

```
get_replies(make_message(bot, '!hi'))
```

By ensuring the retruned event array is unique, this is prevented.

This commit includes specs that ensure this behavior.
