### PR TITLE
MockMessage#initialize: Avoid @channel not initialized warning

### DIFF
--- a/lib/cinch/test.rb
+++ b/lib/cinch/test.rb
@@ -54,10 +54,10 @@ module Cinch
         @user = Cinch::User.new(opts.delete(:nick) { 'test' }, bot)
         if opts.key?(:channel)
           @channel = Cinch::Channel.new(opts.delete(:channel), bot)
+          @target = @channel
+        else
+          @target = @user
         end
-
-        # set the message target
-        @target = @channel || @user
 
         @bot.user_list.find_ensured(nil, @user.nick, nil)
       end


### PR DESCRIPTION
Otherwise, when testing with Ruby warnings enabled, I see many warnings:

/home/pt/.gem/ruby/2.2.0/gems/cinch-test-0.1.1/lib/cinch/test.rb:60:
warning: instance variable @channel not initialized

One for every message I create that doesn't have a channel (and if I'm
testing a lot of commands that go directly to a bot, this could be many)
