### PR TITLE
v0.1.2 - Fix private messages sent directly to bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
    with `get_replies(message)`
 
 ## Changelog
+* 0.1.2 (April 25, 2016)
+    * [Bug Fix] Responses for private messages no longer fire twice.
+    * [Bug Fix] Avoid a @channel not initialized warning for private messages.
 * 0.0.4 (July 2, 2013)
     * [Bug Fix] Should now capture any user.send|notice|privmsg, channel.send|action events that
         were previously ignored.

--- a/lib/cinch/test/version.rb
+++ b/lib/cinch/test/version.rb
@@ -1,6 +1,6 @@
 module Cinch
   # Versioning Info
   module Test
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end


### PR DESCRIPTION
Hi, I'm back again, wondering if it would be appropriate to release v0.1.2. I do have a few projects with tests that could benefit from this. It's true that I can work around (make sure my bot functions are idempotent, set mock expectations to allow at least 1 call instead of exactly 1 call, and/or source this gem from git directly rather than v0.1.1), but it seems good to get the changes out.

It may be the case that you do not take this PR in its current form, since I would not be able to publish the new version myself anyway, that would be up to you. Ultimately this PR is just a suggestion of what could go in the changelog, if the changelog is a thing you want to keep up to date.

Thanks for your help.
